### PR TITLE
all pushed to main will not create latest tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
             lukasz/yosoy
             ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest
+            type=edge
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
all pushed to main will not create latest tag (reserved for versions now) - instead edge tag (used widely in docker community) is pushed